### PR TITLE
added easy_install commands for tornado, pika, pyzmq

### DIFF
--- a/install_superpack.sh
+++ b/install_superpack.sh
@@ -73,7 +73,12 @@ echo 'Installing nose ...'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z nose
 echo 'Installing DateUtils'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z DateUtils
-
+echo 'Installing Tornado'
+${SUDO} "${PYTHON}" -m easy_install -N -Z tornado
+echo 'Installing pyzmq'
+${SUDO} "${PYTHON}" -m easy_install -N -Z pyzmq
+echo 'Installing pika'
+${SUDO} "${PYTHON}" -m easy_install -N -Z pika
 if  [ "$local" == "n" ] || [ "$local" == "N" ]; then  
     echo 'Cleaning up'  
     rm -rf ${SUPERPACK_PATH}


### PR DESCRIPTION
added easy_install for tornado, pika, pyzmq. This enabled me to get ipython notebook running on a fresh OSX Lion installation after executing install_superpack.sh. I figured this would be a good addition because the superpack includes ipython.
