### PR TITLE
Added missing dependency for statsmodels

### DIFF
--- a/install_superpack.sh
+++ b/install_superpack.sh
@@ -79,6 +79,8 @@ echo 'Installing pyzmq'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z pyzmq
 echo 'Installing pika'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z pika
+echo 'Installing patsy'
+${SUDO} "${PYTHON}" -m easy_install -N -Z patsy
 if  [ "$local" == "n" ] || [ "$local" == "N" ]; then  
     echo 'Cleaning up'  
     rm -rf ${SUPERPACK_PATH}


### PR DESCRIPTION
The module patsy is used for the formula parsing in the latest statsmodels version. It was missing from the installed packages resulting in an error upon importing statsmodels
