### PR TITLE
update install_superpack.sh

### DIFF
--- a/install_superpack.sh
+++ b/install_superpack.sh
@@ -75,6 +75,8 @@ echo 'Installing six'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z six
 echo 'Installing python-dateutil'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z python-dateutil
+echo 'Installing pytz'
+${SUDO} "${PYTHON}" -m easy_install -N -Z pytz
 echo 'Installing Tornado'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z tornado
 echo 'Installing pyzmq'


### PR DESCRIPTION
I observed that a lot of unit tests were skipped in pandas because they rely on pytz. To make ScipySuperpack more useful 'out of the box' I suggest to add the timezone library. See also the note on optional dependencies at http://pandas.pydata.org/pandas-docs/stable/install.html#dependencies
