### PR TITLE
Pyparsing fails to install

### DIFF
--- a/install_superpack.sh
+++ b/install_superpack.sh
@@ -68,7 +68,7 @@ ${SUDO} "${PYTHON}" -m easy_install -N -Z nose
 echo 'Installing six'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z six
 echo 'Installing pyparsing'
-${SUDO} "${PYTHON}" -m easy_install -N -Z pyparsing
+${SUDO} "${PYTHON}" -m easy_install -N -Z pyparsing==1.5.7
 echo 'Installing python-dateutil'
 ${SUDO} "${PYTHON}" -m easy_install -N -Z python-dateutil
 echo 'Installing pytz'


### PR DESCRIPTION
pyparsing 2.0 is for Python 3.x only. The last version to support Python 2.x is 1.5.7. The call to easy install must specify that.
