### PR TITLE
Clone the numpy repository over https

### DIFF
--- a/install_superpack.sh
+++ b/install_superpack.sh
@@ -47,7 +47,7 @@ export BLAS=/usr/local/opt/openblas/lib/libopenblas.a
 export LAPACK=/usr/local/opt/openblas/lib/libopenblas.a
 
 # Build from cloned repo to avoid SciPy build issue
-git clone git@github.com:numpy/numpy.git numpy_temp
+git clone https://github.com/numpy/numpy.git numpy_temp
 cd numpy_temp
 python setupegg.py bdist_egg
 easy_install dist/*egg


### PR DESCRIPTION
Cloning the numpy repository over ssh failed for me. I think https is a more reliable method which does not depend on the user having an ssh key set up with github.
